### PR TITLE
Use `windows-latest` as `windows-2019` is deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, ubuntu-latest]
+        os: [windows-latest, ubuntu-latest]
 
     steps:
       - name: Fetch sources
@@ -52,7 +52,7 @@ jobs:
         run: brew install ninja
 
       - name: Configure CMake
-        run: cmake -G "${{ matrix.os=='windows-2019' && 'Visual Studio 16 2019' || 'Ninja' }}" -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=RelWithDebInfo ${{matrix.additional_cmake_flags}} -DAUI_INSTALL_RUNTIME_DEPENDENCIES=TRUE
+        run: cmake -G "${{ matrix.os=='windows-latest' && 'Visual Studio 17 2022' || 'Ninja' }}" -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=RelWithDebInfo ${{matrix.additional_cmake_flags}} -DAUI_INSTALL_RUNTIME_DEPENDENCIES=TRUE
 
       - name: Build Project
         run: cmake --build ${{github.workspace}}/build --config RelWithDebInfo


### PR DESCRIPTION
Showcase: https://github.com/Alex2772/neuro-organizer-app/pull/1